### PR TITLE
11 add missing paging support via nexttoken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules
 src/.aws-sam
-aggregated_results.txt
-.idea

--- a/src/lambdas/GetInstances/index.mjs
+++ b/src/lambdas/GetInstances/index.mjs
@@ -14,16 +14,16 @@ async function getInstances (region) {
   const params = {}
   let res
   do {
-        if (res && res.NextToken) {
-          params.NextToken = res.NextToken
-        }
-      const command = new DescribeInstancesCommand(params)
-      res = await client.send(command)
-      for (const reserve of res.Reservations) {
-        for (const instance of reserve.Instances) {
-          instances.push({ id: instance.InstanceId, type: instance.InstanceType })
-        }
+    if (res && res.NextToken) {
+      params.NextToken = res.NextToken
+    }
+    const command = new DescribeInstancesCommand(params)
+    res = await client.send(command)
+    for (const reserve of res.Reservations) {
+      for (const instance of reserve.Instances) {
+        instances.push({ id: instance.InstanceId, type: instance.InstanceType })
       }
+    }
   } while (res.NextToken)
   return instances
 }

--- a/src/lambdas/GetInstances/index.mjs
+++ b/src/lambdas/GetInstances/index.mjs
@@ -12,15 +12,19 @@ async function getInstances (region) {
     region
   })
   const params = {}
-  const command = new DescribeInstancesCommand(params)
-  const res = await client.send(command)
-  console.log('res: ', res)
-  for (const reserve of res.Reservations) {
-    for (const instance of reserve.Instances) {
-      console.log(instance.InstanceId, instance.InstanceType)
-      instances.push({ id: instance.InstanceId, type: instance.InstanceType })
-    }
-  }
+  let res
+  do {
+        if (res && res.NextToken) {
+          params.NextToken = res.NextToken
+        }
+      const command = new DescribeInstancesCommand(params)
+      res = await client.send(command)
+      for (const reserve of res.Reservations) {
+        for (const instance of reserve.Instances) {
+          instances.push({ id: instance.InstanceId, type: instance.InstanceType })
+        }
+      }
+  } while (res.NextToken)
   return instances
 }
 export const handler = async (event) => {

--- a/src/lambdas/GetUsage/index.mjs
+++ b/src/lambdas/GetUsage/index.mjs
@@ -33,15 +33,22 @@ const params = {
 }
 
 export const handler = async (event) => {
-  const command = new GetCostAndUsageCommand(params)
-  const res = await client.send(command)
   const regions = new Set()
-  for (const result of res.ResultsByTime) {
-    for (const group of result.Groups) {
-      for (const key of group.Keys) {
-        regions.add(key)
+  let res
+  do {
+    if (res && res.NextToken) {
+      params.NextToken = res.NextToken
+    }
+    const command = new GetCostAndUsageCommand(params)
+    res = await client.send(command)
+
+    for (const result of res.ResultsByTime) {
+      for (const group of result.Groups) {
+        for (const key of group.Keys) {
+          regions.add(key)
+        }
       }
     }
-  }
+  } while (res.NextToken)
   return [...regions]
 }

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -189,7 +189,7 @@ Resources:
             MemorySize: 128
             Role: !GetAtt GetInstancesRole.Arn
             Runtime: "nodejs18.x"
-            Timeout: 3
+            Timeout: 10
 
     AmazonEventBridgeSchedulerRole:
         Type: "AWS::IAM::Role"


### PR DESCRIPTION
*Issue #11:*

*Description of changes:*

Added paging support (using `NextToken`) for the retrieval of individual instances (`GetInstances`) and regions (`GetUsage`), only first page was being processed.

Additional:
- Cleaned `.gitignore` file to exclude temp & vendor specific files
- Increased `GetInstances` lambda timeout as current setting wasn't enough in some tested cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
